### PR TITLE
refactor: validate tests against package directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ public class Sample {
 
 In the context of this plugin, this annotation/comment on the class means that _the tests that should cover this test class are called `SampleTest` and `SuperSampleTest`_.
 
-> Note: By default, this tool with not check if those classes exist within your project. If you want to check that test methods are found in your package directories, provide the optional `--ignore-missing-tests` flag. When the flag is provided, a warning will be printed for each test class it is unable to find in any of your package directories and will not add those missing tests to the final output.
+> Note: By default, this tool with not check if those classes exist within your project. If you want to check that test methods are found in your package directories, provide the optional `--ignore-missing-tests` Boolean flag. When the flag is provided, a warning will be printed for each test class it is unable to find in any of your package directories and will not add those missing tests to the final output.
 
 Then, assuming you want to run only the tests provided at the top level of your classes, use the command as follows:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ public class Sample {
 
 In the context of this plugin, this annotation/comment on the class means that _the tests that should cover this test class are called `SampleTest` and `SuperSampleTest`_.
 
-> Note: The tool will check if those classes exist within your project. A warning will be printed for each test class it is unable to find in any of your package directories.
+> Note: By default, this tool with not check if those classes exist within your project. If you want to check that test methods are found in your package directories, provide the optional `--ignore-missing-tests` flag. When the flag is provided, a warning will be printed for each test class it is unable to find in any of your package directories and will not add those missing tests to the final output.
 
 Then, assuming you want to run only the tests provided at the top level of your classes, use the command as follows:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A plugin that generates a list of tests that your, ideally, automated process sh
 
 ## Usage
 
-List all files specified in the classes of a certain directory (and subfolders) and have the result be in the format for the CLI.
+List all files specified in the classes in your package directories and have the result be in the format for the CLI.
 
 The classes should have a comment starting with `@Tests` somewhere. This is what the tool reads to return the tests. For example, the `Sample.cls` file in the `samples` folder contains a comment like this:
 
@@ -19,12 +19,12 @@ public class Sample {
 
 In the context of this plugin, this annotation/comment on the class means that _the tests that should cover this test class are called `SampleTest` and `SuperSampleTest`_.
 
-> Note: The tool does not check if those classes exist within your project, so make sure to keep the annotations up-to-date.
+> Note: The tool will check if those classes exist within your project. A warning will be printed for each test class it is unable to find in any of your package directories.
 
 Then, assuming you want to run only the tests provided at the top level of your classes, use the command as follows:
 
 ```sh
-sf apextests list --directory force-app --format sf
+sf apextests list --format sf
 $ --tests SampleTest SuperSampleTest Sample2Test SuperSample2Test
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ public class Sample {
 
 In the context of this plugin, this annotation/comment on the class means that _the tests that should cover this test class are called `SampleTest` and `SuperSampleTest`_.
 
-> Note: By default, this tool with not check if those classes exist within your project. If you want to check that test methods are found in your package directories, provide the optional `--ignore-missing-tests` Boolean flag. When the flag is provided, a warning will be printed for each test class it is unable to find in any of your package directories and will not add those missing tests to the final output.
+> Note: By default, this tool does not check if those classes exist within your project, so make sure to keep the annotations up-to-date. If you want to check that test annotations are found in your package directories, provide the optional `--ignore-missing-tests` Boolean flag. When the flag is provided, a warning will be printed for each test annotation it is unable to find in any of your package directories and will not add those missing annotations to the final output.
 
 Then, assuming you want to run only the tests provided at the top level of your classes, use the command as follows:
 

--- a/messages/apextests.list.md
+++ b/messages/apextests.list.md
@@ -4,15 +4,7 @@ List
 
 # description
 
-Lists tests in a package.xml file or from a directory.
-
-# flags.directory.summary
-
-Directory name. Defaults to the current working directory.
-
-# flags.directory.description
-
-Usually, if you run this command at the root of your Salesforce DX project, it means that the directory points to the original "force-app" folder (even if you have renamed it to something else). If you wish to limit the usage to a specific module, specify the folder with this flag.
+Lists tests in a package.xml file or from your package directories.
 
 # flags.format.summary
 
@@ -28,10 +20,10 @@ Manifest XML file.
 
 # flags.manifest.description
 
-When you specify a manifest file, the plugin will not search directories for all classes with annotations, but instead will read the manifest file and search for those classes within the specified directory.
+When you specify a manifest file, the plugin will not search directories for all classes with annotations, but instead will read the manifest file and search for those classes within your package directories.
 
 # examples
 
 - <%= config.bin %> <%= command.id %> --format csv
-- <%= config.bin %> <%= command.id %> --format sf --directory force-app
+- <%= config.bin %> <%= command.id %> --format sf
 - <%= config.bin %> <%= command.id %> --format sf --manifest package.xml

--- a/messages/apextests.list.md
+++ b/messages/apextests.list.md
@@ -22,8 +22,17 @@ Manifest XML file.
 
 When you specify a manifest file, the plugin will not search directories for all classes with annotations, but instead will read the manifest file and search for those classes within your package directories.
 
+# flags.ignore-missing-tests.summary
+
+Ignore missing test methods.
+
+# flags.ignore-missing-tests.description
+
+If provided, ignore test methods that are not found in any of the package directories.
+
 # examples
 
 - <%= config.bin %> <%= command.id %> --format csv
 - <%= config.bin %> <%= command.id %> --format sf
 - <%= config.bin %> <%= command.id %> --format sf --manifest package.xml
+- <%= config.bin %> <%= command.id %> --format sf --manifest package.xml --ignore-missing-tests

--- a/samples/classes/Sample2Test.cls
+++ b/samples/classes/Sample2Test.cls
@@ -1,0 +1,7 @@
+@isTest
+class sampleTest {
+    @isTest
+    public static void sampleTest() {
+        // Create and insert test data
+    }
+  }

--- a/samples/classes/SampleTest.cls
+++ b/samples/classes/SampleTest.cls
@@ -1,0 +1,7 @@
+@isTest
+class sampleTest {
+    @isTest
+    public static void sampleTest() {
+        // Create and insert test data
+    }
+  }

--- a/samples/classes/SampleTriggerTest.cls
+++ b/samples/classes/SampleTriggerTest.cls
@@ -1,0 +1,7 @@
+@isTest
+class sampleTest {
+    @isTest
+    public static void sampleTest() {
+        // Create and insert test data
+    }
+  }

--- a/samples/classes/SuperSample2Test.cls
+++ b/samples/classes/SuperSample2Test.cls
@@ -1,0 +1,7 @@
+@isTest
+class sampleTest {
+    @isTest
+    public static void sampleTest() {
+        // Create and insert test data
+    }
+  }

--- a/samples/classes/SuperSampleTest.cls
+++ b/samples/classes/SuperSampleTest.cls
@@ -1,0 +1,7 @@
+@isTest
+class sampleTest {
+    @isTest
+    public static void sampleTest() {
+        // Create and insert test data
+    }
+  }

--- a/samples/classes/Warning.cls
+++ b/samples/classes/Warning.cls
@@ -1,0 +1,6 @@
+// @Tests: NotYourLuckyDayTest
+public class Sample {
+  public void say(String msg) {
+    System.debug(msg);
+  }
+}

--- a/src/commands/apextests/list.ts
+++ b/src/commands/apextests/list.ts
@@ -191,7 +191,10 @@ export default class ApextestsList extends SfCommand<ApextestsListResult> {
 
       if (validatedTests.length > 0) {
         finalTestMethods = validatedTests;
+      } else {
+        throw new Error('No test methods declared in your annotations were found in your package directories.')
       }
+
         // Log any warnings
       if (warnings.length > 0) {
         warnings.forEach((warning) => {

--- a/src/helpers/validateTests.ts
+++ b/src/helpers/validateTests.ts
@@ -1,0 +1,56 @@
+'use strict';
+/* eslint-disable no-await-in-loop */
+
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export async function validateTests(
+  unvalidatedTests: string[],
+  packageDirectories: string[]
+): Promise<{ validatedTests: string[]; warnings: string[] }> {
+  const warnings: string[] = [];
+  const validatedTests: string[] = [];
+
+  for (const unvalidatedTest of unvalidatedTests) {
+    // Pass the test method with the ".cls" extension
+    const testPath = await findFilePath(`${unvalidatedTest}.cls`, packageDirectories);
+    if (testPath === undefined) {
+      warnings.push(`The test method ${unvalidatedTest}.cls was not found in any package directory.`);
+    } else {
+      validatedTests.push(unvalidatedTest);
+    }
+  }
+  return { validatedTests, warnings };
+}
+
+export async function findFilePath(
+  fileName: string,
+  packageDirectories: string[]
+): Promise<string | undefined> {
+  let relativeFilePath: string | undefined;
+  for (const directory of packageDirectories) {
+    relativeFilePath = await searchRecursively(fileName, directory);
+    if (relativeFilePath !== undefined) {
+      break;
+    }
+  }
+  return relativeFilePath;
+}
+
+async function searchRecursively(fileName: string, dxDirectory: string): Promise<string | undefined> {
+  const files = await readdir(dxDirectory);
+  for (const file of files) {
+    const filePath = join(dxDirectory, file);
+    const stats = await stat(filePath);
+    if (stats.isDirectory()) {
+      // Recursively search inside subdirectories
+      const result = await searchRecursively(fileName, filePath);
+      if (result) {
+        return result;
+      }
+    } else if (file === fileName) {
+      return filePath;
+    }
+  }
+  return undefined;
+}

--- a/test/commands/apextests/list.nut.ts
+++ b/test/commands/apextests/list.nut.ts
@@ -38,14 +38,14 @@ describe('apextests list NUTs', () => {
   });
 
   it('runs list', async () => {
-    const command = 'apextests list';
+    const command = 'apextests list --ignore-missing-tests';
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     expect(output.replace('\n', '')).to.equal(`--tests ${TEST_LIST.join(' ')}`);
   });
 
   it('runs list with --json', async () => {
-    const command = 'apextests list --json';
+    const command = 'apextests list --json --ignore-missing-tests';
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -53,7 +53,7 @@ describe('apextests list NUTs', () => {
   });
 
   it('runs list --format csv', async () => {
-    const command = `apextests list ${['--format', 'csv'].join(' ')} --json`;
+    const command = `apextests list ${['--format', 'csv', '--ignore-missing-tests'].join(' ')} --json`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/test/commands/apextests/list.test.ts
+++ b/test/commands/apextests/list.test.ts
@@ -43,6 +43,11 @@ describe('apextests list', () => {
       .flatMap((c) => c.args)
       .join(' ');
     expect(output).to.equal(`--tests ${TEST_LIST.join(' ')}`);
+    const warnings = sfCommandStubs.warn
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join('\n');
+    expect(warnings).to.include('The test method NotYourLuckyDayTest.cls was not found in any package directory.');
   });
 
   it('runs list with --json', async () => {
@@ -57,6 +62,11 @@ describe('apextests list', () => {
       .flatMap((c) => c.args)
       .join(' ');
     expect(output).to.equal(TEST_LIST.join(','));
+    const warnings = sfCommandStubs.warn
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join('\n');
+    expect(warnings).to.include('The test method NotYourLuckyDayTest.cls was not found in any package directory.');
   });
 
   it('runs list --format csv --manifest samples/samplePackage.xml', async () => {
@@ -66,6 +76,11 @@ describe('apextests list', () => {
       .flatMap((c) => c.args)
       .join(' ');
     expect(output).to.equal('SampleTest,SuperSampleTest');
+    const warnings = sfCommandStubs.warn
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join('\n');
+    expect(warnings).to.include('');
   });
 
   it('runs list --format csv --manifest samples/samplePackageWithTrigger.xml', async () => {
@@ -80,5 +95,10 @@ describe('apextests list', () => {
       .flatMap((c) => c.args)
       .join(' ');
     expect(output).to.equal('SampleTest,SampleTriggerTest,SuperSampleTest');
+    const warnings = sfCommandStubs.warn
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join('\n');
+    expect(warnings).to.include('');
   });
 });

--- a/test/commands/apextests/list.test.ts
+++ b/test/commands/apextests/list.test.ts
@@ -37,7 +37,7 @@ describe('apextests list', () => {
   });
 
   it('runs list', async () => {
-    await ApextestsList.run([]);
+    await ApextestsList.run(['--ignore-missing-tests']);
     const output = sfCommandStubs.log
       .getCalls()
       .flatMap((c) => c.args)
@@ -51,12 +51,12 @@ describe('apextests list', () => {
   });
 
   it('runs list with --json', async () => {
-    const result = await ApextestsList.run([]);
+    const result = await ApextestsList.run(['--ignore-missing-tests']);
     expect(result.command).to.equal(`--tests ${TEST_LIST.join(' ')}`);
   });
 
   it('runs list --format csv', async () => {
-    await ApextestsList.run(['--format', 'csv']);
+    await ApextestsList.run(['--format', 'csv', '--ignore-missing-tests']);
     const output = sfCommandStubs.log
       .getCalls()
       .flatMap((c) => c.args)


### PR DESCRIPTION
Here's a way you can validate the test methods against your package directories. I'm doing something similar to this with a plugin I wrote for apex code coverage.

This will print a warning for each test method it's unable to find in any of the package directories. I'm also updating the readme and messages since I forget to remove the references for the old `--directory` flag.

To do this, I had to create sample test method files from your previous annotations.

Up to you if you want to accept this change, since it will enforce users to deploy their local tests from a Git repo in order to use this. I think I know most orgs choose to deploy their local Apex code (not from managed packages) from a source-backed repo like Git, so I'm not sure if there are many cases where orgs would have different sources for their local apex (??).