### PR TITLE
fix: convert to set to remove duplicate test methods

### DIFF
--- a/samples/classes/Sample2.cls
+++ b/samples/classes/Sample2.cls
@@ -1,4 +1,4 @@
-// @Tests:Sample2Test , SuperSample2Test
+// @Tests:Sample2Test , SuperSample2Test,SuperSampleTest
 public class Sample2 {
   public void say(String msg) {
     System.debug(msg);

--- a/src/commands/apextests/list.ts
+++ b/src/commands/apextests/list.ts
@@ -184,11 +184,15 @@ export default class ApextestsList extends SfCommand<ApextestsListResult> {
       const testMethodsInDir = await ApextestsList.searchTestClasses(directory, testClassesNames);
       allTestMethods.push(...testMethodsInDir);
     }
-    let finalTestMethods = allTestMethods; // default to allTestMethods
+
+    // Ensure all test methods are unique by using a Set
+    let finalTestMethods = Array.from(
+      new Set(allTestMethods.map((test) => test.trim()))
+    );
 
     // If ignore-missing-tests is true, validate the test methods
     if (ignoreMissingTests) {
-      const { validatedTests, warnings } = await validateTests(allTestMethods, packageDirectories);
+      const { validatedTests, warnings } = await validateTests(finalTestMethods, packageDirectories);
 
       if (validatedTests.length > 0) {
         finalTestMethods = validatedTests;


### PR DESCRIPTION
I caught this minor issue when smoke-testing the latest plugin version against my team's repo.

If multiple apex classes contain the same test annotations, the final output will contain duplicate test methods. This shouldn't cause any failures/etc. when deploying, but this would just create a longer output if someone is parsing through it. This will also trim any whitespace in the annotations.

If you convert the array to a Set, it will remove the duplicate entries. After the set is created, it's converted back to an array before proceeding forward.