### PR TITLE
docs: fix changelog formatting and add usage code block to readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
+<!-- markdownlint-disable MD024 MD025 -->
+<!-- markdown-link-check-disable -->
+
 # Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ## [1.4.0](https://github.com/renatoliveira/apex-test-list/compare/v1.1.0...v1.4.0) (2024-09-20)
 
@@ -10,10 +15,3 @@
 
 - convert to set to remove duplicate test methods ([3385541](https://github.com/renatoliveira/apex-test-list/commit/3385541b86d9570a89bb4a33a771baecc824c826))
 - reverts Yarn version in packageManager to 1.22.22 ([7ec0c02](https://github.com/renatoliveira/apex-test-list/commit/7ec0c02b52ae7b9f98052cd1dc7c81573f449dbb))
-
-<!-- markdownlint-disable MD024 MD025 -->
-<!-- markdown-link-check-disable -->
-
-## Changelog
-
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.

--- a/README.md
+++ b/README.md
@@ -47,3 +47,38 @@ This then becomes the full command to deploy and run only the tests that you - i
 ```sh
 sf project deploy start --tests SampleTest SuperSampleTest Sample2Test SuperSample2Test SampleTriggerTest
 ```
+
+```
+USAGE
+  $ sf apextests list -f <value> -x <value> -s [--json]
+
+FLAGS
+  -f, --format=<value> By default, the format being returned is a list in the format that can be merged with the test flags of the Salesforce CLI deploy and validate commands.
+                       Available formats are `sf` (default) and `csv`.
+  -x, --manifest=<value> Manifest XML file (package.xml).
+  -s, --ignore-missing-tests  [default: false] If this Boolean flag is provided, ignore test methods that are not found in any of your local package directories.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Lists tests in a package.xml file or from your package directories.
+
+EXAMPLES
+  List all test annotations found in all of your package directories in the Salesforce CLI format:
+
+    $ sf apextests list --format sf
+
+  List all test annotations found in all of your package directories in CSV format:
+
+    $ sf apextests list --format csv
+
+  List test annotations found only in the Apex classes/triggers listed in a manifest file:
+
+    $ sf apextests list --format sf --manifest package.xml
+
+  List test annotations only if they have been found in any of your local package directories:
+
+    $ sf apextests list --format sf --ignore-missing-tests
+
+```


### PR DESCRIPTION
Minor update to the CHANGELOG file to fix some formatting in markdown. I would accept this change before you push any changes to your default branch which would trigger a Release Please PR. I'm pretty sure the CHANGELOG formatting will be weird if you don't accept these updates to re-arrange the headers.

I'm also suggesting adding this "code" block in your README which lists out all possible flags for your command and examples there. I'm pretty sure the template provides this and I think most users provide this in their Salesforce CLI plugins to ensure all flags and their possible choices are provided. I know they can get this by running the `--help` command, but having it in your README might help onboard newer users to this easier.

You can discard the README update if you'd like, but I would highly recommend pushing the CHANGELOG fix via this PR or manually yourself so you don't see any weird formatting when Release Please creates a new PR and updates the CHANGELOG for you.