### PR TITLE
fix: include colon in the regex

### DIFF
--- a/src/helpers/readers.ts
+++ b/src/helpers/readers.ts
@@ -7,8 +7,8 @@ import { queue } from 'async';
 import { parseTestsNames, parseTestSuiteFile, parseTestSuitesNames } from './parsers.js';
 import { SearchResult } from './types.js';
 
-const TEST_NAME_REGEX = /(@tests).+/gi;
-const TEST_SUITE_NAME_REGEX = /(@testsuites).+/gi;
+const TEST_NAME_REGEX = /(@tests\s*:\s*).+/gi;
+const TEST_SUITE_NAME_REGEX = /(@testsuites\s*:\s*).+/gi;
 const TEST_CLASS_ANNOTATION_REGEX = /@istest\n(private|public|global)/gi;
 
 export function getConcurrencyThreshold(): number {


### PR DESCRIPTION
My last update seems to have found this issue with the 2 regexes. Since the colon wasn't in the regex, the "testsuites" regex would be true with the "tests" regex.

Including the colon in the regex (ignoring how many spaces are between the annotation and colon) seems to fix this test failure.