### PR TITLE
ci: run tests before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,22 @@ permissions:
   pull-requests: write
 
 jobs:
+  unit-tests:
+    uses: salesforcecli/github-workflows/.github/workflows/unitTest.yml@main
+  nuts:
+    needs: unit-tests
+    uses: salesforcecli/github-workflows/.github/workflows/nut.yml@main
+    secrets: inherit
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
+    with:
+      os: ${{ matrix.os }}
   release:
     name: Release
     runs-on: ubuntu-latest
+    needs: [unit-tests, nuts]
     steps:
       - name: Release Please
         id: release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: tests
 on:
   push:
-    branches-ignore: [main]
+    branches-ignore: [master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Here's a way you can enforce your tests are passing before you run the Release job.

I tried to just reference your existing "test.yml" in your "release.yml", but GitHub threw this error about exceeding the max workflow depth of 3, thus why I needed to copy the unit tests and nuts jobs into release.

```
Invalid workflow file: .github/workflows/release.yml#L13
error parsing called workflow
".github/workflows/release.yml"
-> "./.github/workflows/test.yml" (source branch with sha:3c0edb358c30463ef078d325ca2bc6687cee041d)
--> "salesforcecli/github-workflows/.github/workflows/unitTest.yml@main" (source branch with sha:c7e9d40bd3cadc88584846a4042be49f2caa6483)
---> "salesforcecli/github-workflows/.github/workflows/unitTestsLinux.yml@main" (source branch with sha:c7e9d40bd3cadc88584846a4042be49f2caa6483)
: job "prevent-typescript-dependency" calls workflow "salesforcecli/github-workflows/.github/workflows/preventTypescriptDep.yml@main", but doing so would exceed the limit on called workflow depth of 3
```

Here's what your new Release workflow on master branch would look like. It will only run Release after both Unit and NUTS pass.

![image](https://github.com/user-attachments/assets/000628fe-63b8-466d-a8af-b32d0dd51e71)
