### PR TITLE
fix: ignore cases in prefixes and allow spaces as separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ sf plugins install apextestlist
 
 List all files specified in the classes in your package directories and have the result be in the format for the CLI.
 
-The classes should have a comment starting with `@Tests` somewhere. This is what the tool reads to return the tests. For example, the `Sample.cls` file in the `samples` folder contains a comment like this:
+The classes should have a comment starting with the `@Tests:` prefix somewhere. This is what the tool reads to return the tests. You can separate multiple tests by commas, spaces, or both. This tool will parse both and remove extra spaces it may find.
+
+For example, the `Sample.cls` file in the `samples` folder contains a comment like this:
 
 ```java
 // @Tests: SampleTest,SuperSampleTest
@@ -25,16 +27,16 @@ public class Sample {
 }
 ```
 
-Optionally, you may add also test suites to the annotation:
+Optionally, you may add also test suites with the `@TestSuites:` prefix to the annotation. Like with tests, multiple test suites can be separated by any combination of commas or spaces.
 
 ```java
-// @TestSuites: SampleSuite
+// @TestSuites: SampleSuite SampleSuite2
 public class Sample {
   // ...
 }
 ```
 
-And you can add a mix of both too, if needed.
+And you can add a mix of both too, if needed. Both test annotation prefixes are case-insensitive, but the tests themselves should match the cases as they appear in Salesforce.
 
 In the context of this plugin, this annotation/comment on the class means that _the tests that should cover this test class are called `SampleTest` and `SuperSampleTest`_.
 

--- a/samples/classes/Sample2.cls
+++ b/samples/classes/Sample2.cls
@@ -1,4 +1,5 @@
-// @Tests:Sample2Test , SuperSample2Test,SuperSampleTest
+// Annotations are intentionally separated by multiple spaces to test extreme cases
+// @Tests   :    Sample2Test , SuperSample2Test     SuperSampleTest
 public class Sample2 {
   public void say(String msg) {
     System.debug(msg);

--- a/src/helpers/parsers.ts
+++ b/src/helpers/parsers.ts
@@ -76,11 +76,11 @@ export function parseTestsNames(testNames: string[] | null): string[] {
 
   // remove the prefix @Tests
   return testNames
-    .join(',')
-    .split(',')
-    .map((line) => line.replace(/(@tests):/i, ''))
-    .map((line) => line.trim())
-    .filter((line) => line);
+    .join(' ')
+    .replace(/(@tests\s*:\s*)/gi, '')
+    .replace(/[,\s]+/g, ' ')
+    .trim()
+    .split(' ');
 }
 
 /**
@@ -96,9 +96,9 @@ export function parseTestSuitesNames(testSuitesNames: string[] | null): string[]
 
   // remove the prefix @testsuites
   return testSuitesNames
-    .join(',')
-    .split(',')
-    .map((line) => line.replace(/(@testsuites):/i, ''))
-    .map((line) => line.trim())
-    .filter((line) => line);
+    .join(' ')
+    .replace(/(@testsuites\s*:\s*)/gi, '')
+    .replace(/[,\s]+/g, ' ')
+    .trim()
+    .split(' ');
 }


### PR DESCRIPTION
My developers definitely test these extreme use cases out pretty well. We have an existing Apex Header template, which has them list things like `@classname:` , `@author:` , etc. I've seen these headers get any combination of spaces in and around these annotations.

It would be nice if the regexes would allow multiple spaces before and after the `:` , as well as between multiple tests.

I also think the regexes should allow for multiple tests to be separated by spaces as well as commas, since this plugin's output will separate multiple tests by a single space.

It also looks like the 2 functions which remove the prefixes don't have the ignore cases update to them (`.map((line) => line.replace(/(@tests):/i, ''))`).

I've updated your 1 sample class to handle these use cases with some heavy spaces