### PR TITLE
fix: stop the regex match at the end of the line

### DIFF
--- a/src/helpers/readers.ts
+++ b/src/helpers/readers.ts
@@ -7,8 +7,8 @@ import { queue } from 'async';
 import { parseTestsNames, parseTestSuiteFile, parseTestSuitesNames } from './parsers.js';
 import { SearchResult } from './types.js';
 
-const TEST_NAME_REGEX = /(@tests\s*:\s*).+/gi;
-const TEST_SUITE_NAME_REGEX = /(@testsuites\s*:\s*).+/gi;
+const TEST_NAME_REGEX = /@tests\s*:\s*([^/\n]+)/gi; 
+const TEST_SUITE_NAME_REGEX = /@testsuites\s*:\s*([^/\n]+)/gi; 
 const TEST_CLASS_ANNOTATION_REGEX = /@istest\n(private|public|global)/gi;
 
 export function getConcurrencyThreshold(): number {

--- a/test/commands/apextests/list.nut.ts
+++ b/test/commands/apextests/list.nut.ts
@@ -5,7 +5,20 @@ import { expect } from 'chai';
 
 import { SFDX_PROJECT_FILE_NAME } from '../../../src/helpers/constants.js';
 
+// only tests which exist in the samples directory
+const VALIDATED_TEST_LIST = [
+  'Sample2Test',
+  'SampleTest',
+  'SampleTriggerTest',
+  'SuperSample2Test',
+  'SuperSampleTest',
+  'UnlistedTest',
+  'UnlistedTest2',
+].sort((a, b) => a.localeCompare(b));
+
+// all tests provided in the sample annotations
 const TEST_LIST = [
+  'NotYourLuckyDayTest',
   'Sample2Test',
   'SampleTest',
   'SampleTriggerTest',
@@ -46,14 +59,14 @@ describe('apextests list NUTs', () => {
   });
 
   it('runs list', async () => {
-    const command = 'apextests list --ignore-missing-tests';
+    const command = 'apextests list';
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     expect(output.replace('\n', '')).to.equal(`--tests ${TEST_LIST.join(' ')}`);
   });
 
   it('runs list with --json', async () => {
-    const command = 'apextests list --json --ignore-missing-tests';
+    const command = 'apextests list --json';
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -61,11 +74,34 @@ describe('apextests list NUTs', () => {
   });
 
   it('runs list --format csv', async () => {
-    const command = `apextests list ${['--format', 'csv', '--ignore-missing-tests'].join(' ')} --json`;
+    const command = `apextests list ${['--format', 'csv'].join(' ')} --json`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(JSON.parse(output).result.command).to.equal(TEST_LIST.join(','));
+  });
+
+  it('runs list and validates tests exist', async () => {
+    const command = 'apextests list --ignore-missing-tests';
+    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
+
+    expect(output.replace('\n', '')).to.equal(`--tests ${VALIDATED_TEST_LIST.join(' ')}`);
+  });
+
+  it('runs list with --json and validates tests exist', async () => {
+    const command = 'apextests list --json --ignore-missing-tests';
+    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(JSON.parse(output).result.command).to.equal(`--tests ${VALIDATED_TEST_LIST.join(' ')}`);
+  });
+
+  it('runs list --format csv and validates tests exist', async () => {
+    const command = `apextests list ${['--format', 'csv', '--ignore-missing-tests'].join(' ')} --json`;
+    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(JSON.parse(output).result.command).to.equal(VALIDATED_TEST_LIST.join(','));
   });
 
   it('runs list --format csv --manifest samples/samplePackage.xml', async () => {

--- a/test/commands/apextests/list.test.ts
+++ b/test/commands/apextests/list.test.ts
@@ -6,7 +6,20 @@ import ApextestsList from '../../../src/commands/apextests/list.js';
 
 import { SFDX_PROJECT_FILE_NAME } from '../../../src/helpers/constants.js';
 
+// only tests which exist in the samples directory
+const VALIDATED_TEST_LIST = [
+  'Sample2Test',
+  'SampleTest',
+  'SampleTriggerTest',
+  'SuperSample2Test',
+  'SuperSampleTest',
+  'UnlistedTest',
+  'UnlistedTest2',
+].sort((a, b) => a.localeCompare(b));
+
+// all tests provided in the sample annotations
 const TEST_LIST = [
+  'NotYourLuckyDayTest',
   'Sample2Test',
   'SampleTest',
   'SampleTriggerTest',
@@ -44,12 +57,35 @@ describe('apextests list', () => {
   });
 
   it('runs list', async () => {
-    await ApextestsList.run(['--ignore-missing-tests']);
+    await ApextestsList.run([]);
     const output = sfCommandStubs.log
       .getCalls()
       .flatMap((c) => c.args)
       .join(' ');
     expect(output).to.equal(`--tests ${TEST_LIST.join(' ')}`);
+  });
+
+  it('runs list with --json', async () => {
+    const result = await ApextestsList.run([]);
+    expect(result.command).to.equal(`--tests ${TEST_LIST.sort((a, b) => a.localeCompare(b)).join(' ')}`);
+  });
+
+  it('runs list --format csv', async () => {
+    await ApextestsList.run(['--format', 'csv']);
+    const output = sfCommandStubs.log
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join(' ');
+    expect(output).to.equal(TEST_LIST.sort((a, b) => a.localeCompare(b)).join(','));
+  });
+
+  it('runs list and validates tests exist', async () => {
+    await ApextestsList.run(['--ignore-missing-tests']);
+    const output = sfCommandStubs.log
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join(' ');
+    expect(output).to.equal(`--tests ${VALIDATED_TEST_LIST.join(' ')}`);
     const warnings = sfCommandStubs.warn
       .getCalls()
       .flatMap((c) => c.args)
@@ -57,18 +93,18 @@ describe('apextests list', () => {
     expect(warnings).to.include('The test method NotYourLuckyDayTest.cls was not found in any package directory.');
   });
 
-  it('runs list with --json', async () => {
+  it('runs list with --json and validates tests exist', async () => {
     const result = await ApextestsList.run(['--ignore-missing-tests']);
-    expect(result.command).to.equal(`--tests ${TEST_LIST.sort((a, b) => a.localeCompare(b)).join(' ')}`);
+    expect(result.command).to.equal(`--tests ${VALIDATED_TEST_LIST.sort((a, b) => a.localeCompare(b)).join(' ')}`);
   });
 
-  it('runs list --format csv', async () => {
+  it('runs list --format csv and validates tests exist', async () => {
     await ApextestsList.run(['--format', 'csv', '--ignore-missing-tests']);
     const output = sfCommandStubs.log
       .getCalls()
       .flatMap((c) => c.args)
       .join(' ');
-    expect(output).to.equal(TEST_LIST.sort((a, b) => a.localeCompare(b)).join(','));
+    expect(output).to.equal(VALIDATED_TEST_LIST.sort((a, b) => a.localeCompare(b)).join(','));
     const warnings = sfCommandStubs.warn
       .getCalls()
       .flatMap((c) => c.args)


### PR DESCRIPTION
https://github.com/renatoliveira/apex-test-list/issues/65

Stop the RegEx when the EOL is found.

Update the tests to include the validated tests (with the `-i` flag) and the unvalidated tests (without the `-i` flag) which is just the addition of the `NotYourLuckyDay` test annotation which does not exist in your samples directory.