### PR TITLE
feat: remove dependency on git repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A plugin that generates a list of tests that your, ideally, automated process should run, so you can save time by not running all tests in your Salesforce org and also save time by not specifying them manually.
 
+This plugin is intended to be ran in any version control repository that follows the Salesforce DX project structure (`sfdx-project.json` file).
+
 ## Install
 
 Simply issue a install command with `sf`, as in:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@salesforce/core": "^8.6.1",
     "@salesforce/sf-plugins-core": "^11.3.12",
     "async": "^3.2.6",
-    "isomorphic-git": "^1.27.1",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
@@ -38,7 +37,8 @@
     "/lib",
     "/messages",
     "/oclif.manifest.json",
-    "/oclif.lock"
+    "/oclif.lock",
+    "/CHANGELOG.md"
   ],
   "keywords": [
     "force",

--- a/src/helpers/getRepoRoot.ts
+++ b/src/helpers/getRepoRoot.ts
@@ -1,14 +1,32 @@
 'use strict';
-import { promises as fsPromises, readFile, stat, readdir } from 'node:fs';
-import git from 'isomorphic-git';
+/* eslint-disable no-await-in-loop */
+import { access } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
 
-export async function getRepoRoot(): Promise<string> {
-  const fs = { promises: fsPromises, readFile, stat, readdir };
+import { SFDX_PROJECT_FILE_NAME } from './constants.js';
 
-  const repoRoot = await git.findRoot({
-    fs,
-    filepath: process.cwd(),
-  });
-
-  return repoRoot;
+export async function getRepoRoot(): Promise<{ repoRoot: string | undefined; dxConfigFilePath: string | undefined }> {
+  let currentDir = process.cwd();
+  let found = false;
+  let dxConfigFilePath: string | undefined;
+  let repoRoot: string | undefined;
+  do {
+    const filePath = join(currentDir, SFDX_PROJECT_FILE_NAME);
+    try {
+      // Check if sfdx-project.json exists in the current directory
+      await access(filePath);
+      dxConfigFilePath = filePath;
+      repoRoot = currentDir;
+      found = true;
+    } catch {
+      // If file not found, move up one directory level
+      const parentDir = dirname(currentDir);
+      if (currentDir === parentDir) {
+        // Reached the root without finding the file, throw an error
+        throw new Error(`${SFDX_PROJECT_FILE_NAME} not found in any parent directory.`);
+      }
+      currentDir = parentDir;
+    }
+  } while (!found);
+  return { repoRoot, dxConfigFilePath };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,10 +2470,6 @@ assertion-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz"
 
-async-lock@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz"
-
 async-retry@^1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz"
@@ -2737,10 +2733,6 @@ ci-info@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz"
 
-clean-git-ref@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz"
-
 clean-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz"
@@ -2959,10 +2951,6 @@ cosmiconfig@^9.0.0:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
 
-crc-32@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz"
-
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
@@ -3115,10 +3103,6 @@ devlop@^1.0.0:
   resolved "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz"
   dependencies:
     dequal "^2.0.0"
-
-diff3@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz"
 
 diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
@@ -4212,7 +4196,7 @@ ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
 
-ignore@^5.1.4, ignore@^5.2.0, ignore@^5.2.4, ignore@^5.3.0:
+ignore@^5.2.0, ignore@^5.2.4, ignore@^5.3.0:
   version "5.3.2"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
 
@@ -4482,22 +4466,6 @@ isarray@~1.0.0:
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-
-isomorphic-git@^1.27.1:
-  version "1.27.1"
-  resolved "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.27.1.tgz"
-  dependencies:
-    async-lock "^1.4.1"
-    clean-git-ref "^2.0.1"
-    crc-32 "^1.2.0"
-    diff3 "0.0.3"
-    ignore "^5.1.4"
-    minimisted "^2.0.0"
-    pako "^1.0.10"
-    pify "^4.0.1"
-    readable-stream "^3.4.0"
-    sha.js "^2.4.9"
-    simple-get "^4.0.1"
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"
@@ -5106,15 +5074,9 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
+minimist@^1.2.0, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
-
-minimisted@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz"
-  dependencies:
-    minimist "^1.2.5"
 
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.2"
@@ -5454,7 +5416,7 @@ package-json-from-dist@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz"
 
-pako@^1.0.10, pako@~1.0.2:
+pako@~1.0.2:
   version "1.0.11"
   resolved "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz"
 
@@ -5561,10 +5523,6 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
 picomatch@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz"
-
-pify@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz"
 
 pino-abstract-transport@^1.0.0, pino-abstract-transport@^1.2.0:
   version "1.2.0"
@@ -6011,13 +5969,6 @@ setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
 
-sha.js@^2.4.9:
-  version "2.4.11"
-  resolved "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz"
-  dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
-
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
@@ -6063,18 +6014,6 @@ signal-exit@^3.0.2, signal-exit@^3.0.3:
 signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
-
-simple-concat@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz"
-
-simple-get@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz"
-  dependencies:
-    decompress-response "^6.0.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
 
 sinon@10.0.0:
   version "10.0.0"
@@ -6220,15 +6159,7 @@ srcset@^5.0.0:
   version "5.0.1"
   resolved "https://registry.npmjs.org/srcset/-/srcset-5.0.1.tgz"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   dependencies:
@@ -6296,13 +6227,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   dependencies:
@@ -6834,7 +6759,7 @@ workerpool@^6.5.1:
   version "6.5.1"
   resolved "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   dependencies:
@@ -6845,14 +6770,6 @@ workerpool@^6.5.1:
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
I was making this update in my plugins and thought I'd do the same here since I contributed the original code to find the git repo root.

I know Git is the most popular VCS, but there could be users that use different VCS's depending on their work/etc. 

The only reason we need to find the repo root folder is to look for the [`sfdx-project.json`](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_ws_config.htm) file. This file could be in any Salesforce DX project repo regardless of which VCS they are using.

This request removes the need for the `isomorphic-git` dependency and will use native fs modules to search for the `sfdx-project.json` file. If the file isn't found in the current running directory, it will search upwards til it finds it or it hits the root drive. If it doesn't find the file, it will fail as it should fail in this scenario.

I think this update will make your plugin available to all Salesforce CLI users, not just those in git repos.

MINOR `package.json` update: Include the CHANGELOG so that it's included when building the plugin in NPM. Just did that for mine since the CHANGELOG is not automatically included in the build by default.