### PR TITLE
fix: ignore cases on type names in manifest files

### DIFF
--- a/samples/samplePackageWithTrigger.xml
+++ b/samples/samplePackageWithTrigger.xml
@@ -7,11 +7,11 @@ the test annotated on it as well.
   <types>
     <members>Sample</members>
     <members>SampleTest</members>
-    <name>ApexClass</name>
+    <name>apexclass</name>
   </types>
   <types>
     <members>Sample</members>
-    <name>ApexTrigger</name>
+    <name>apextrigger</name>
   </types>
   <version>62.0</version>
 </Package>

--- a/src/helpers/parsers.ts
+++ b/src/helpers/parsers.ts
@@ -23,13 +23,21 @@ export async function extractTypeNamesFromManifestFile(manifestFile: string): Pr
     .parseStringPromise(readFileSync(manifestFile, 'utf-8'))
     .then((parsed: { Package: { types: Array<{ name: string; members: string[] }> } }) => {
       parsed.Package.types.forEach((type: { name: string; members: string[] }) => {
-        if (
-          type.name.includes('ApexClass') ||
-          type.name.includes('ApexTrigger') ||
-          type.name.includes('ApexTestSuite')
-        ) {
+        const typeName = String(type.name);
+        const typeNameLower = typeName.toLowerCase();
+
+        let normalizedTypeName = '';
+        if (typeNameLower === 'apexclass') {
+          normalizedTypeName = 'ApexClass';
+        } else if (typeNameLower === 'apextrigger') {
+          normalizedTypeName = 'ApexTrigger';
+        } else if (typeNameLower === 'apextestsuite') {
+          normalizedTypeName = 'ApexTestSuite';
+        }
+
+        if (normalizedTypeName) {
           type.members.forEach((member) => {
-            result.push(`${type.name}:${member}`);
+            result.push(`${normalizedTypeName}:${member}`);
           });
         }
       });


### PR DESCRIPTION
I was testing this plugin out with my new plugin that combines package.xml files (https://github.com/mcarvin8/sf-package-combiner). This drove me crazy in figuring out why I couldn't get your plugin to work with my plugin until I realized it was casing 😆 

Because Salesforce allows the `<name>` key in a package.xml to be case insensitive (ex: `apexclass`), I updated my plugin to convert all cases to lower-case to ensure multiple package types in multiple packages are always grouped together correctly. 

Ideally, you don't need to worry about this if you use sfdx-git-delta. But if you make manifest files manually or some other way, you can't always ensure the name cases match since Salesforce does not care about the cases of the metadata name. The members are the only items case sensitive since that needs to match API names in Salesforce.

Please accept this fix to ignore cases in just the `<name>` keys in a manifest file.

I'm maintaining the "normalized" case type names that you have hard-coded elsewhere (these line up with how a sfdx-git-delta package would be created as well): 
- ApexClass
- ApexTrigger
- ApexTestSuite

So basically, no matter the case used in the package.xml, it will be assigned to one of the 3 above "normalized" names.