### PR TITLE
refactor: remove await in loop

### DIFF
--- a/src/helpers/getRepoRoot.ts
+++ b/src/helpers/getRepoRoot.ts
@@ -1,32 +1,27 @@
 'use strict';
-/* eslint-disable no-await-in-loop */
 import { access } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 
 import { SFDX_PROJECT_FILE_NAME } from './constants.js';
 
-export async function getRepoRoot(): Promise<{ repoRoot: string | undefined; dxConfigFilePath: string | undefined }> {
-  let currentDir = process.cwd();
-  let found = false;
-  let dxConfigFilePath: string | undefined;
-  let repoRoot: string | undefined;
-  do {
-    const filePath = join(currentDir, SFDX_PROJECT_FILE_NAME);
-    try {
-      // Check if sfdx-project.json exists in the current directory
-      await access(filePath);
-      dxConfigFilePath = filePath;
-      repoRoot = currentDir;
-      found = true;
-    } catch {
-      // If file not found, move up one directory level
-      const parentDir = dirname(currentDir);
-      if (currentDir === parentDir) {
-        // Reached the root without finding the file, throw an error
-        throw new Error(`${SFDX_PROJECT_FILE_NAME} not found in any parent directory.`);
-      }
-      currentDir = parentDir;
+async function findRepoRoot(dir: string): Promise<{ repoRoot: string | undefined; dxConfigFilePath: string | undefined }> {
+  const filePath = join(dir, SFDX_PROJECT_FILE_NAME);
+  try {
+    // Check if sfdx-project.json exists in the current directory
+    await access(filePath);
+    return { repoRoot: dir, dxConfigFilePath: filePath };
+  } catch {
+    const parentDir = dirname(dir);
+    if (dir === parentDir) {
+      // Reached the root without finding the file, throw an error
+      throw new Error('sfdx-project.json not found in any parent directory.');
     }
-  } while (!found);
-  return { repoRoot, dxConfigFilePath };
+    // Recursively search in the parent directory
+    return findRepoRoot(parentDir);
+  }
+}
+
+export async function getRepoRoot(): Promise<{ repoRoot: string | undefined; dxConfigFilePath: string | undefined }> {
+  const currentDir = process.cwd();
+  return findRepoRoot(currentDir);
 }


### PR DESCRIPTION
@renatoliveira here's a minor refactoring that removes the eslint disable I had in the original file.

I don't think it warrants a fix release but up to you if you want to change this commit message to trigger the `fix: ` release.

I'm trying to see if I can remove the await in the loop in `src\helpers\getPackageDirectories.ts` (which I have my own versions in my plugins) but that one is a little more complicated and I'm not sure if I can remove the awaits in a loop without changing the logic around.