### PR TITLE
feat: ignore package directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,16 @@ sf project deploy start --tests SampleTest SuperSampleTest Sample2Test SuperSamp
 
 ```
 USAGE
-  $ sf apextests list -f <value> -x <value> -s [--json]
+  $ sf apextests list -f <value> -x <value> -s -d <value> [--json]
 
 FLAGS
-  -f, --format=<value> By default, the format being returned is a list in the format that can be merged with the test flags of the Salesforce CLI deploy and validate commands.
-                       Available formats are `sf` (default) and `csv`.
-  -x, --manifest=<value> Manifest XML file (package.xml).
-  -s, --ignore-missing-tests  [default: false] If this Boolean flag is provided, ignore test methods that are not found in any of your local package directories.
+  -f, --format=<value>            By default, the format being returned is a list in the format that can be merged with the test flags of the Salesforce CLI deploy and validate commands.
+                                  Available formats are `sf` (default) and `csv`.
+  -x, --manifest=<value>          Manifest XML file (package.xml).
+  -s, --ignore-missing-tests      [default: false] If this Boolean flag is provided, ignore test methods that are not found in any of your local package directories.
+  -d, --ignore-package-directory  Ignore a package directory when looking for test annotations.
+                                  Should match how they are declared in the "sfdx-project.json".
+                                  Can be declared multiple times.
 
 GLOBAL FLAGS
   --json  Format output as json.
@@ -95,5 +98,9 @@ EXAMPLES
   List test annotations only if they have been found in any of your local package directories:
 
     $ sf apextests list --format sf --ignore-missing-tests
+
+  List all test annotations except for those found in the "force-app" directory.
+
+    $ sf apextests list -d "force-app"
 
 ```

--- a/messages/apextests.list.md
+++ b/messages/apextests.list.md
@@ -30,9 +30,18 @@ Ignore missing test methods.
 
 If provided, ignore test methods that are not found in any of the package directories.
 
+# flags.ignore-package-directory.summary
+
+Ignore a package directory.
+
+# flags.ignore-package-directory.description
+
+If provided, do not search the package directory for test annotations.
+
 # examples
 
 - <%= config.bin %> <%= command.id %> --format csv
 - <%= config.bin %> <%= command.id %> --format sf
 - <%= config.bin %> <%= command.id %> --format sf --manifest package.xml
 - <%= config.bin %> <%= command.id %> --format sf --manifest package.xml --ignore-missing-tests
+- <%= config.bin %> <%= command.id %> --format sf --manifest package.xml -d "force-app"

--- a/src/commands/apextests/list.ts
+++ b/src/commands/apextests/list.ts
@@ -46,6 +46,13 @@ export default class ApextestsList extends SfCommand<ApextestsListResult> {
       char: 's',
       default: false,
     }),
+    'ignore-package-directory': Flags.directory({
+      summary: messages.getMessage('flags.ignore-package-directory.summary'),
+      description: messages.getMessage('flags.ignore-package-directory.description'),
+      char: 'd',
+      required: false,
+      multiple: true,
+    }),
   };
 
   public async run(): Promise<ApextestsListResult> {
@@ -54,13 +61,14 @@ export default class ApextestsList extends SfCommand<ApextestsListResult> {
     const format = flags.format ?? 'sf';
     const manifest = flags.manifest ?? undefined;
     const ignoreMissingTests = flags['ignore-missing-tests'] ?? false;
+    const ignoreDirs = flags['ignore-package-directory'] ?? [];
 
     let result: Promise<ApextestsListResult> | null = null;
     let testClassesNames: string[] | null = null;
     const testSuitesNames: string[] = [];
 
     // Get package directories full paths
-    const packageDirectories = await getPackageDirectories();
+    const packageDirectories = await getPackageDirectories(ignoreDirs);
 
     if (manifest) {
       const manifesMetadata = await extractTypeNamesFromManifestFile(manifest);

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,2 +1,3 @@
 'use strict';
 export const SFDX_PROJECT_FILE_NAME = 'sfdx-project.json';
+export const SEARCHABLE_METADATA_FOLDERS = ['classes', 'triggers', 'testSuites'];

--- a/src/helpers/getPackageDirectories.ts
+++ b/src/helpers/getPackageDirectories.ts
@@ -1,15 +1,13 @@
 'use strict';
-/* eslint-disable no-await-in-loop */
 
-import { resolve, join } from 'node:path';
+import { resolve, join, basename } from 'node:path';
 import { readFile, readdir, stat } from 'node:fs/promises';
 
 import { getRepoRoot } from './getRepoRoot.js';
 import { SfdxProject } from './types.js';
+import { SEARCHABLE_METADATA_FOLDERS } from './constants.js';
 
-const SEARCHABLE_METADATA_FOLDERS = ['classes', 'triggers', 'testSuites'];
-
-export async function getPackageDirectories(): Promise<string[]> {
+export async function getPackageDirectories(ignoreDirs: string[]): Promise<string[]> {
   const { repoRoot, dxConfigFilePath } = await getRepoRoot();
 
   if (!repoRoot || !dxConfigFilePath) {
@@ -19,16 +17,15 @@ export async function getPackageDirectories(): Promise<string[]> {
   process.chdir(repoRoot);
   const sfdxProjectRaw: string = await readFile(dxConfigFilePath, 'utf-8');
   const sfdxProject: SfdxProject = JSON.parse(sfdxProjectRaw) as SfdxProject;
-  const packageDirectories = sfdxProject.packageDirectories.map((directory) => resolve(repoRoot, directory.path));
-  const metadataPaths: string[] = [];
+  const packageDirectories = sfdxProject.packageDirectories
+  .map((directory) => resolve(repoRoot, directory.path))
+  .filter((directory) => !ignoreDirs.includes(basename(directory)));
 
-  for (const directory of packageDirectories) {
-    const mdPath = await searchForSubFolders(directory, SEARCHABLE_METADATA_FOLDERS);
-
-    if (mdPath.length > 0) {
-      metadataPaths.push(...mdPath);
-    }
-  }
+  const metadataPaths = (
+    await Promise.all(
+      packageDirectories.map((directory) => searchForSubFolders(directory, SEARCHABLE_METADATA_FOLDERS))
+    )
+  ).flat();
 
   return metadataPaths;
 }
@@ -37,19 +34,22 @@ async function searchForSubFolders(dxDirectory: string, subDirectoryNames: strin
   const foundPaths: string[] = [];
   const files = await readdir(dxDirectory);
 
-  for (const file of files) {
-    const filePath = join(dxDirectory, file);
-    const stats = await stat(filePath);
+  const subfolderChecks = await Promise.all(
+    files.map(async (file) => {
+      const filePath = join(dxDirectory, file);
+      const stats = await stat(filePath);
 
-    // Check if current directory is one of the desired sub-folders
-    if (stats.isDirectory() && subDirectoryNames.includes(file)) {
-      foundPaths.push(filePath);
-    }
-    // Recursively search sub-directories that aren't the target folders
-    else if (stats.isDirectory()) {
-      const result = await searchForSubFolders(filePath, subDirectoryNames);
-      foundPaths.push(...result);
-    }
+      if (stats.isDirectory() && subDirectoryNames.includes(file)) {
+        return [filePath];
+      } else if (stats.isDirectory()) {
+        return searchForSubFolders(filePath, subDirectoryNames);
+      }
+      return [];
+    })
+  );
+
+  for (const paths of subfolderChecks) {
+    foundPaths.push(...paths);
   }
 
   return foundPaths;

--- a/test/commands/apextests/list.nut.ts
+++ b/test/commands/apextests/list.nut.ts
@@ -1,4 +1,4 @@
-import { rm, writeFile } from 'node:fs/promises';
+import { rm, writeFile, mkdir, rmdir } from 'node:fs/promises';
 import * as path from 'node:path';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
@@ -40,9 +40,11 @@ describe('apextests list NUTs', () => {
     sourceApiVersion: '58.0',
   };
   const configJsonString = JSON.stringify(configFile, null, 2);
+  const ignoreDir = 'ignore';
 
   before(async () => {
     await writeFile(SFDX_PROJECT_FILE_NAME, configJsonString);
+    await mkdir(ignoreDir);
   });
 
   before(async () => {
@@ -52,6 +54,7 @@ describe('apextests list NUTs', () => {
   after(async () => {
     await session?.clean();
     await rm(SFDX_PROJECT_FILE_NAME);
+    await rmdir(ignoreDir);
   });
 
   it('should display the help information', () => {
@@ -61,14 +64,14 @@ describe('apextests list NUTs', () => {
   });
 
   it('runs list', async () => {
-    const command = 'apextests list';
+    const command = `apextests list -d ${ignoreDir}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     expect(output.replace('\n', '')).to.equal(`--tests ${TEST_LIST.join(' ')}`);
   });
 
   it('runs list with --json', async () => {
-    const command = 'apextests list --json';
+    const command = `apextests list --json -d ${ignoreDir}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -76,7 +79,7 @@ describe('apextests list NUTs', () => {
   });
 
   it('runs list --format csv', async () => {
-    const command = `apextests list ${['--format', 'csv'].join(' ')} --json`;
+    const command = `apextests list ${['--format', 'csv'].join(' ')} --json -d ${ignoreDir}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -84,14 +87,14 @@ describe('apextests list NUTs', () => {
   });
 
   it('runs list and validates tests exist', async () => {
-    const command = 'apextests list --ignore-missing-tests';
+    const command = `apextests list --ignore-missing-tests -d ${ignoreDir}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     expect(output.replace('\n', '')).to.equal(`--tests ${VALIDATED_TEST_LIST.join(' ')}`);
   });
 
   it('runs list with --json and validates tests exist', async () => {
-    const command = 'apextests list --json --ignore-missing-tests';
+    const command = `apextests list --json --ignore-missing-tests -d ${ignoreDir}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -99,7 +102,7 @@ describe('apextests list NUTs', () => {
   });
 
   it('runs list --format csv and validates tests exist', async () => {
-    const command = `apextests list ${['--format', 'csv', '--ignore-missing-tests'].join(' ')} --json`;
+    const command = `apextests list ${['--format', 'csv', '--ignore-missing-tests'].join(' ')} --json -d ${ignoreDir}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -107,7 +110,7 @@ describe('apextests list NUTs', () => {
   });
 
   it('runs list --format csv --manifest samples/samplePackage.xml', async () => {
-    const command = `apextests list --format csv --manifest ${path.join('samples', 'samplePackage.xml')}`;
+    const command = `apextests list --format csv --manifest ${path.join('samples', 'samplePackage.xml')} -d ${ignoreDir}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     expect(output.replace('\n', '')).to.equal(
@@ -118,7 +121,7 @@ describe('apextests list NUTs', () => {
   });
 
   it('runs list --format csv --manifest samples/samplePackageWithTrigger.xml', async () => {
-    const command = `apextests list --format csv --manifest ${path.join('samples', 'samplePackageWithTrigger.xml')}`;
+    const command = `apextests list --format csv --manifest ${path.join('samples', 'samplePackageWithTrigger.xml')} -d ${ignoreDir}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
 
     expect(output.replace('\n', '')).to.equal(


### PR DESCRIPTION
@renatoliveira - Here's an update I pushed in my plugins, might help you. Kinda similar to your original plugin version, except just ignoring a specific directory over allowing a specific directory.

By default, the plugin will search all package directories to find files to look for test annotations in.

This update adds an optional directory flag, which can be specified multiple times if a user wants to ignore multiple directories. If the flag is provided at least once, it will provide a non-empty array and if it matches an entry in the `sfdx-project.json`, it will not process that directory for test annotations.

I also figured out how to refactor the `getPackageDirectories` and `validateTests` functions to remove awaits in loops, so they should run faster.