### PR TITLE
fix: istest annotation parsing

### DIFF
--- a/src/helpers/readers.ts
+++ b/src/helpers/readers.ts
@@ -9,7 +9,7 @@ import { SearchResult } from './types.js';
 
 const TEST_NAME_REGEX = /@tests\s*:\s*([^/\n]+)/gi;
 const TEST_SUITE_NAME_REGEX = /@testsuites\s*:\s*([^/\n]+)/gi;
-const TEST_CLASS_ANNOTATION_REGEX = /@istest\n(private|public|global)/gi;
+const TEST_CLASS_ANNOTATION_REGEX = /@istest\n\s*(private|public|global)/gi;
 
 export function getConcurrencyThreshold(): number {
   const AVAILABLE_PARALLELISM: number = availableParallelism ? availableParallelism() : Infinity;


### PR DESCRIPTION
One last thing for today. While testing out in my work repo, when the manifest file just contained 1 test class, I had intermittent success with the plugin returning test methods.

Looks like the regex for finding `@isTest` in a unit test is susceptible to any whitespace/indenting that's in between the `@isTest` and the `private|public|global` bit. 

I tested this out by updating your `SampleTest.cls`. In its current state, if your manifest file just contains `SampleTest`, it will not return any test methods. If you remove the additional space before public/private/static on the newline, it will return that test method `SampleTest`.

To ensure this always works, I think you just need to update your regex to allow for any combination of spaces/indents before the public/private bit.