### PR TITLE
fix: remove newline parsing from test class regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ public class Sample {
 
 And you can add a mix of both too, if needed. Both test annotation prefixes are case-insensitive, but the tests themselves should match the cases as they appear in Salesforce.
 
+The tool also searches for the `@isTest` [annotation](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_annotation_isTest.htm) present in all unit tests. If the tool finds the `@isTest` annotation, it will add that unit test to the output in addition.
+
 In the context of this plugin, this annotation/comment on the class means that _the tests that should cover this test class are called `SampleTest` and `SuperSampleTest`_.
 
 > Note: By default, this tool does not check if those classes exist within your project, so make sure to keep the annotations up-to-date. If you want to check that test annotations are found in your package directories, provide the optional `--ignore-missing-tests` Boolean flag. When the flag is provided, a warning will be printed for each test annotation it is unable to find in any of your package directories and will not add those missing annotations to the final output.

--- a/src/helpers/readers.ts
+++ b/src/helpers/readers.ts
@@ -9,7 +9,7 @@ import { SearchResult } from './types.js';
 
 const TEST_NAME_REGEX = /@tests\s*:\s*([^/\n]+)/gi;
 const TEST_SUITE_NAME_REGEX = /@testsuites\s*:\s*([^/\n]+)/gi;
-const TEST_CLASS_ANNOTATION_REGEX = /@istest\n(private|public|global)/gi;
+const TEST_CLASS_ANNOTATION_REGEX = /@istest/gi;
 
 export function getConcurrencyThreshold(): number {
   const AVAILABLE_PARALLELISM: number = availableParallelism ? availableParallelism() : Infinity;

--- a/test/units/readers.test.ts
+++ b/test/units/readers.test.ts
@@ -10,7 +10,7 @@ describe('tests of the searchDirectoryForTestNamesInTestSuites fn', () => {
     const suitePath = './samples/testSuites';
     const result = await searchDirectoryForTestNamesInTestSuites(suitePath, ['./samples/classes']);
 
-    expect(result).to.deep.equal(['UnlistedTest', 'NS.UnlistedTest', 'Sample2Test', 'SampleTest'].sort());
+    expect(result).to.deep.equal(['UnlistedTest', 'NS.UnlistedTest', 'Sample2Test', 'SampleTriggerTest', 'SampleTest'].sort());
   });
 });
 
@@ -39,7 +39,7 @@ describe('test suite wildcards', () => {
   it('should read the SampleSuite test suite file and list the test classes with wildcards', async () => {
     const suitePath = './samples/testSuites';
     const result = await searchDirectoryForTestNamesInTestSuites(suitePath, ['./samples/classes']);
-    const tests = ['NS.UnlistedTest', 'UnlistedTest', 'Sample2Test', 'SampleTest'].sort();
+    const tests = ['NS.UnlistedTest', 'UnlistedTest', 'Sample2Test', 'SampleTriggerTest', 'SampleTest'].sort();
 
     expect(result).to.deep.equal(tests);
   });


### PR DESCRIPTION
Fixes an issue I've seen with `@isTest` annotation parsing, specifically in a use case where only 1 unit test is in a manifest file like below:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
  <types>
    <members>SuperSampleTest</members>
    <name>ApexClass</name>
  </types>
  <version>62.0</version>
</Package>
```

Currently with this manifest file above, this fails to find any test annotations including the `@istest` annotation due to the newline attributes being different than how the RegEx has it. The RegEx doesn't account for additional spaces which may be present on the newline or does it work for an `@isTest` followed by `static` in the next line. 

It seems safest to just search for the `@isTest` annotation by itself without caring what is on the next line.