### PR TITLE
provide warnings for missing annotations or no tests found

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A plugin that generates a list of tests that your automated process should run, 
   - [3. `@isTest` (Apex Annotation)](#3-istest-apex-annotation)
 - [Running the Tool](#running-the-tool)
   - [Handling Missing Tests](#handling-missing-tests)
+  - [Handling Missing Annotations](#handling-missing-annotations)
 - [Command Reference](#command-reference)
 - [Issues](#issues)
 - [License](#license)
@@ -95,6 +96,12 @@ The final deployment command would look like:
 sf project deploy start --tests SampleTest SuperSampleTest Sample2Test SuperSample2Test SampleTriggerTest
 ```
 
+If no annotations are found, the command output will be empty and will present this warning:
+
+```sh
+No test methods found
+```
+
 ### Handling Missing Tests
 
 By default, this tool does **not** verify if the tests specified in `@Tests:` or `@TestSuites:` exist in the project. To enable warnings for missing tests, use:
@@ -105,11 +112,25 @@ sf apextests list --ignore-missing-tests
 
 This will print warnings for missing tests and exclude them from the output.
 
+### Handling Missing Annotations
+
+By default, the tool will print a warning for each file scanned that is missing any annotation.
+
+```sh
+File "Sample.cls" does not contain @tests, @testsuites, or @istest annotations
+```
+
+To remove these warnings from the terminal, use:
+
+```sh
+sf apextests list --no-warnings
+```
+
 ## Command Reference
 
 ```
 USAGE
-  $ sf apextests list -f <value> -x <value> -s -d <value> [--json]
+  $ sf apextests list -f <value> -x <value> -s -n -d <value> [--json]
 
 FLAGS
   -f, --format=<value>            Output format. Available options:
@@ -117,6 +138,7 @@ FLAGS
                                     - `csv`: Comma-separated values
   -x, --manifest=<value>          Manifest XML file (package.xml) to filter test annotations.
   -s, --ignore-missing-tests      [default: false] Ignore test methods that are not found in any local package directories.
+  -n, --no-warnings               [default: false] Do not print warnings for each file missing annotations.
   -d, --ignore-package-directory  Ignore a package directory when looking for test annotations.
                                   Should match how they are declared in "sfdx-project.json".
                                   Can be declared multiple times.
@@ -144,6 +166,10 @@ EXAMPLES
   Exclude annotations found in the "force-app" directory:
 
     $ sf apextests list -d "force-app"
+
+  List test annotations without printing warnings for each file missing annotations:
+
+    $ sf apextests list -n
 ```
 
 ## Issues

--- a/messages/apextests.list.md
+++ b/messages/apextests.list.md
@@ -38,6 +38,14 @@ Ignore a package directory.
 
 If provided, do not search the package directory for test annotations.
 
+# flags.no-warnings.summary
+
+Do not print warnings for each Apex file missing annotations.
+
+# flags.no-warnings.description
+
+Do not print warnings for each Apex file missing annotations.
+
 # examples
 
 - <%= config.bin %> <%= command.id %> --format csv

--- a/samples/classes/NoAnnotations.cls
+++ b/samples/classes/NoAnnotations.cls
@@ -1,0 +1,5 @@
+public class NoAnnotations {
+    public void doSomething() {
+        System.debug('Hello World');
+    }
+}

--- a/samples/noAnnotationPackage.xml
+++ b/samples/noAnnotationPackage.xml
@@ -1,0 +1,12 @@
+<!--
+In this sample file, the NoAnnotations class exists but no annotations are in the class.
+The plugin should return an empty output with a warning.
+-->
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>NoAnnotations</members>
+    <name>ApexClass</name>
+  </types>
+  <version>62.0</version>
+</Package>

--- a/src/commands/apextests/list.ts
+++ b/src/commands/apextests/list.ts
@@ -53,6 +53,13 @@ export default class ApextestsList extends SfCommand<ApextestsListResult> {
       required: false,
       multiple: true,
     }),
+    'no-warnings': Flags.boolean({
+      summary: messages.getMessage('flags.no-warnings.summary'),
+      description: messages.getMessage('flags.no-warnings.description'),
+      char: 'n',
+      required: false,
+      default: false,
+    }),
   };
 
   public async run(): Promise<ApextestsListResult> {
@@ -62,69 +69,73 @@ export default class ApextestsList extends SfCommand<ApextestsListResult> {
     const manifest = flags.manifest ?? undefined;
     const ignoreMissingTests = flags['ignore-missing-tests'] ?? false;
     const ignoreDirs = flags['ignore-package-directory'] ?? [];
+    const noWarnings = flags['no-warnings'];
 
-    let result: Promise<ApextestsListResult> | null = null;
     let testClassesNames: string[] | null = null;
     const testSuitesNames: string[] = [];
+    const allTestClasses: string[] = [];
+    const warnings: string[] = [];
 
     // Get package directories full paths
     const packageDirectories = await getPackageDirectories(ignoreDirs);
 
     if (manifest) {
-      const manifesMetadata = await extractTypeNamesFromManifestFile(manifest);
-      testClassesNames = manifesMetadata.filter((name) => !name.endsWith('testSuite-meta.xml'));
+      const manifestMetadata = await extractTypeNamesFromManifestFile(manifest);
+      testClassesNames = manifestMetadata.filter((name) => !name.endsWith('testSuite-meta.xml'));
     }
-
-    const allTestClasses: string[] = [];
 
     // Loop through each directory and search for test classes
     for (const directory of packageDirectories) {
       const searchResult: SearchResult = await searchDirectoryForTestClasses(directory, testClassesNames);
-      const testClassesInDir: string[] = searchResult.classes;
-      const testSuitesMentioned: string[] = searchResult.testSuites;
-
-      allTestClasses.push(...testClassesInDir);
-      testSuitesNames.push(...testSuitesMentioned);
+      allTestClasses.push(...searchResult.classes);
+      testSuitesNames.push(...searchResult.testSuites);
+      if (searchResult.warnings?.length) {
+        warnings.push(...searchResult.warnings);
+      }
     }
 
     if (testSuitesNames.length > 0) {
-      // read the testSuite directory again to get the classes listed on them
       for (const directory of packageDirectories.filter((dir) => dir.includes('testSuites'))) {
         const testNames: string[] = await searchDirectoryForTestNamesInTestSuites(directory, packageDirectories);
         allTestClasses.push(...testNames);
       }
     }
 
-    // Ensure all test methods are unique by using a Set
     let finalTestMethods = Array.from(new Set(allTestClasses.map((test) => test.trim())));
 
     // If ignore-missing-tests is true, validate the test methods
     if (ignoreMissingTests) {
-      const { validatedTests, warnings } = await validateTests(finalTestMethods, packageDirectories);
+      const { validatedTests, warnings: validationWarnings } = await validateTests(finalTestMethods, packageDirectories);
+      finalTestMethods = validatedTests;
 
-      if (validatedTests.length > 0) {
-        finalTestMethods = validatedTests;
-      } else {
-        throw new Error('No test methods declared in your annotations were found in your package directories.');
+      if (validationWarnings.length > 0) {
+        warnings.push(...validationWarnings);
       }
 
-      // Log any warnings
-      if (warnings.length > 0) {
-        warnings.forEach((warning) => {
-          this.warn(warning);
-        });
+      if (validatedTests.length === 0) {
+        warnings.push('No test methods declared in your annotations were found in your package directories');
       }
+    }
+
+    // Print all collected warnings
+    if (!noWarnings && warnings.length > 0) {
+      warnings.forEach((warning) => {
+        this.warn(warning);
+      });
     }
 
     finalTestMethods.sort((a, b) => a.localeCompare(b));
 
-    if (finalTestMethods.length > 0) {
-      result = formatList(format, finalTestMethods);
-    } else {
-      throw new Error('No test methods found');
+    if (finalTestMethods.length === 0) {
+      this.warn('No test methods found');
+      return {
+        tests: [],
+        command: '',
+      };
     }
 
-    this.log((await result).command);
+    const result = await formatList(format, finalTestMethods);
+    this.log(result.command);
     return result;
   }
 }

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -7,4 +7,5 @@ export type SfdxProject = {
 export type SearchResult = {
   classes: string[];
   testSuites: string[];
+  warnings: string[];
 };

--- a/src/helpers/validateTests.ts
+++ b/src/helpers/validateTests.ts
@@ -19,7 +19,7 @@ export async function validateTests(
 
   for (const { test, testPath } of results) {
     if (testPath === undefined) {
-      warnings.push(`The test method ${test}.cls was not found in any package directory.`);
+      warnings.push(`The test method ${test}.cls was not found in any package directory`);
     } else {
       validatedTests.push(test);
     }

--- a/test/commands/apextests/list.test.ts
+++ b/test/commands/apextests/list.test.ts
@@ -95,7 +95,7 @@ describe('apextests list', () => {
       .getCalls()
       .flatMap((c) => c.args)
       .join('\n');
-    expect(warnings).to.include('The test method NotYourLuckyDayTest.cls was not found in any package directory.');
+    expect(warnings).to.include('The test method NotYourLuckyDayTest.cls was not found in any package directory');
   });
 
   it('runs list with --json and validates tests exist', async () => {
@@ -114,7 +114,7 @@ describe('apextests list', () => {
       .getCalls()
       .flatMap((c) => c.args)
       .join('\n');
-    expect(warnings).to.include('The test method NotYourLuckyDayTest.cls was not found in any package directory.');
+    expect(warnings).to.include('The test method NotYourLuckyDayTest.cls was not found in any package directory');
   });
 
   it('runs list --format csv --manifest samples/samplePackage.xml', async () => {
@@ -151,5 +151,31 @@ describe('apextests list', () => {
       .flatMap((c) => c.args)
       .join('\n');
     expect(warnings).to.include('');
+  });
+  it('runs list --manifest samples/noAnnotationPackage.xml', async () => {
+    await ApextestsList.run(['--manifest', 'samples/noAnnotationPackage.xml']);
+    const output = sfCommandStubs.log
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join(' ');
+    expect(output).to.equal('');
+    const warnings = sfCommandStubs.warn
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join('\n');
+    expect(warnings).to.include('File "NoAnnotations.cls" does not contain @tests, @testsuites, or @istest annotations');
+  });
+  it('runs list --manifest samples/noAnnotationPackage.xml --no-warnings', async () => {
+    await ApextestsList.run(['--manifest', 'samples/noAnnotationPackage.xml', '--no-warnings']);
+    const output = sfCommandStubs.log
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join(' ');
+    expect(output).to.equal('');
+    const warnings = sfCommandStubs.warn
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join('\n');
+    expect(warnings).to.include('No test methods found');
   });
 });

--- a/test/units/readers.test.ts
+++ b/test/units/readers.test.ts
@@ -22,6 +22,20 @@ describe('tests of the searchDirectoryForTestClasses fn', () => {
     expect(result).to.deep.equal({
       classes: ['SampleTest', 'SuperSampleTest'],
       testSuites: ['SampleSuite'],
+      warnings: [],
+    });
+  });
+});
+
+describe('tests of the searchDirectoryForTestClasses fn with no annotations', () => {
+  it('should read the NoAnnotations.cls class in the classes directory and return no tests with a warning', async () => {
+    const classesPath = './samples/classes';
+    const result = await searchDirectoryForTestClasses(classesPath, ['ApexClass:NoAnnotations']);
+
+    expect(result).to.deep.equal({
+      classes: [],
+      testSuites: [],
+      warnings: ['File "NoAnnotations.cls" does not contain @tests, @testsuites, or @istest annotations'],
     });
   });
 });


### PR DESCRIPTION
https://github.com/renatoliveira/apex-test-list/issues/177

If no test methods are found, the output will now be empty instead of failing the CLI. A warning will be printed when no test methods are found in all cases.

If users are capturing output like this `tests=$(sf apextests list)`, the `$tests` variable should evaluate to empty which could be checked by a separate script before running the deploy command.

This update also adds warnings for each Apex class/trigger file scanned that is missing any of the 3 annotations. These warnings can be turned off by supplying the new flag `--no-warnings`/`-n`.

If you wanna flip the warning state (i.e. by default print no warnings and provide a `--warn` flag to add the extra warnings), that makes sense too to me.