### PR TITLE
ci: remove testing upon release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,22 +8,9 @@ permissions:
   pull-requests: write
 
 jobs:
-  unit-tests:
-    uses: salesforcecli/github-workflows/.github/workflows/unitTest.yml@main
-  nuts:
-    needs: unit-tests
-    uses: salesforcecli/github-workflows/.github/workflows/nut.yml@main
-    secrets: inherit
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-      fail-fast: false
-    with:
-      os: ${{ matrix.os }}
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [unit-tests, nuts]
     steps:
       - name: Release Please
         id: release


### PR DESCRIPTION
Remove testing in the `release.yml` to speed up Release Please on `master` branch.

I need to look into some way to run testing workflows when PRs are opened from forked repos, but I've seen Sebastien of sfdx-git-delta essentially re-create branches from forks in his repo to enforce his PR workflows. Something to look into for the future if you get other people opening PRs from forks.
