### PR TITLE
switch to ComponentSet when parsing manifest files

### DIFF
--- a/test/units/parsers.test.ts
+++ b/test/units/parsers.test.ts
@@ -9,6 +9,12 @@ describe('tests of the extractTypeNamesFromManifestFile fn', () => {
 
     expect(result).to.deep.equal([]);
   });
+  it('should read a non-existent manifest', async () => {
+    const manifestPath = './samples/invalid.xml';
+    const result = await extractTypeNamesFromManifestFile(manifestPath);
+
+    expect(result).to.deep.equal([]);
+  });
 });
 
 describe('tests of the parseTestSuiteFile fn', () => {


### PR DESCRIPTION
Instead of using `ManifestResolver` and `PackageManifestObject`  from SDR, you could just simply import `ComponentSet` from SDR, which contains built-in functions to parse a manifest file, remove duplicate member entries, normalizes type names to match the registry (i.e. `apexclass` will be normalized to `ApexClass` automatically).

See their handbook, which I've been using to convert my plugins which require parsing manifest files for other reasons.

https://github.com/forcedotcom/source-deploy-retrieve/blob/main/HANDBOOK.md#initializing-a-set-from-a-manifest-file

This update should simplify parsing ApexClass, ApexTrigger, and ApexTestSuite entries from a manifest file while working with your other functions that expect the specific type name casing.

I added a new test which verifies that a non-existent manifest file will still work without breaking the functions. It simply returns no test methods if the manifest file isn't found or is invalid.