### PR TITLE
fix: print --tests before each test listed

### DIFF
--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,12 +1,19 @@
 'use strict';
 import { ApextestsListResult } from '../utils/types.js';
 
+const TESTS_FLAG = '--tests ';
+
 export async function formatList(format: string, tests: string[]): Promise<ApextestsListResult> {
   switch (format) {
     case 'sf':
       return Promise.resolve({
         tests,
-        command: '--tests ' + tests.join(' '),
+        command: TESTS_FLAG + tests.join(` ${TESTS_FLAG}`),
+      });
+    case 'sfdx':
+      return Promise.resolve({
+        tests,
+        command: TESTS_FLAG + tests.join(' '),
       });
     case 'csv':
       return Promise.resolve({

--- a/test/commands/apextests/list.test.ts
+++ b/test/commands/apextests/list.test.ts
@@ -67,15 +67,24 @@ describe('apextests list', () => {
       .getCalls()
       .flatMap((c) => c.args)
       .join(' ');
-    expect(output).to.equal(`--tests ${TEST_LIST.join(' ')}`);
+    expect(output).to.equal(`--tests ${TEST_LIST.join(' --tests ')}`);
   });
 
   it('runs list with --json', async () => {
     const result = await ApextestsList.run(['-d', ignoreDir]);
-    expect(result.command).to.equal(`--tests ${TEST_LIST.sort((a, b) => a.localeCompare(b)).join(' ')}`);
+    expect(result.command).to.equal(`--tests ${TEST_LIST.sort((a, b) => a.localeCompare(b)).join(' --tests ')}`);
   });
 
   it('runs list --format csv', async () => {
+    await ApextestsList.run(['--format', 'csv', '-d', ignoreDir]);
+    const output = sfCommandStubs.log
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join(' ');
+    expect(output).to.equal(TEST_LIST.sort((a, b) => a.localeCompare(b)).join(','));
+  });
+
+  it('runs list --format sfdx', async () => {
     await ApextestsList.run(['--format', 'csv', '-d', ignoreDir]);
     const output = sfCommandStubs.log
       .getCalls()
@@ -90,7 +99,7 @@ describe('apextests list', () => {
       .getCalls()
       .flatMap((c) => c.args)
       .join(' ');
-    expect(output).to.equal(`--tests ${VALIDATED_TEST_LIST.join(' ')}`);
+    expect(output).to.equal(`--tests ${VALIDATED_TEST_LIST.join(' --tests ')}`);
     const warnings = sfCommandStubs.warn
       .getCalls()
       .flatMap((c) => c.args)
@@ -100,7 +109,7 @@ describe('apextests list', () => {
 
   it('runs list with --json and validates tests exist', async () => {
     const result = await ApextestsList.run(['--ignore-missing-tests', '-d', ignoreDir]);
-    expect(result.command).to.equal(`--tests ${VALIDATED_TEST_LIST.sort((a, b) => a.localeCompare(b)).join(' ')}`);
+    expect(result.command).to.equal(`--tests ${VALIDATED_TEST_LIST.sort((a, b) => a.localeCompare(b)).join(' --tests ')}`);
   });
 
   it('runs list --format csv and validates tests exist', async () => {
@@ -184,7 +193,7 @@ describe('apextests list', () => {
       .getCalls()
       .flatMap((c) => c.args)
       .join(' ');
-    expect(output).to.equal('--tests SampleTest SuperSampleTest');
+    expect(output).to.equal('--tests SampleTest --tests SuperSampleTest');
     const warnings = sfCommandStubs.warn
       .getCalls()
       .flatMap((c) => c.args)


### PR DESCRIPTION
The existing implementation of `apextests list` only prints `--tests` once, then space-separates each subsequent test. This works in POSIX-compatible shells, but not in others like `fish` and `nu`.

Ideally, each test has `--tests` listed before it; this is the approach suggested in [the `sf apex run test` docs](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_apex_commands_unified.htm#cli_reference_apex_run_test_unified).

I left the legacy approach as a `sfdx` format option that can be accessed if needed.