### PR TITLE
ci: decouple release-please from npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,12 @@ jobs:
       fail-fast: false
     with:
       os: ${{ matrix.os }}
-  release:
-    name: Release
+  release-please:
+    name: Release Please
     runs-on: ubuntu-latest
     needs: [unit-tests, nuts]
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - name: Release Please
         id: release
@@ -31,9 +33,14 @@ jobs:
         with:
           release-type: node
 
+  publish:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-        if: ${{ steps.release.outputs.release_created == 'true' }}
 
       - name: Setup Node
         uses: actions/setup-node@v4.0.1
@@ -41,18 +48,14 @@ jobs:
           node-version: 22
           cache: yarn
           registry-url: 'https://registry.npmjs.org'
-        if: ${{ steps.release.outputs.release_created == 'true' }}
 
       - name: Install Dependencies
         run: yarn install
-        if: ${{ steps.release.outputs.release_created == 'true' }}
 
       - name: Build
         run: yarn build
-        if: ${{ steps.release.outputs.release_created == 'true' }}
 
       - name: Publish to NPM
         run: npm publish --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: ${{ steps.release.outputs.release_created == 'true' }}


### PR DESCRIPTION
## Summary

- Splits the single `release` job into two independent jobs: `release-please` and `publish`
- `release-please` job exposes `release_created` as a job output
- `publish` job depends on that output and skips entirely if no release was created

## Why

Release Please can fail intermittently due to GitHub API issues. Previously this blocked the entire job, making it impossible to re-run cleanly — re-running would either re-attempt npm publish unnecessarily or fail before reaching it. Now each job can be re-run independently.

## Test plan

- [ ] Merge a PR and verify `release-please` job runs and creates release PR as expected
- [ ] Verify `publish` job only runs when `release_created == 'true'`
- [ ] Simulate `release-please` failure and confirm re-run works without touching NPM

🤖 Generated with [Claude Code](https://claude.com/claude-code)