### PR TITLE
test: kill surviving mutants and report them on PRs

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Run incremental mutation testing
         env:
           MUTATION_BASE_BRANCH: origin/${{ github.base_ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run test:mutation:incremental
 
       - name: Upload mutation report

--- a/scripts/incremental-mutation.mjs
+++ b/scripts/incremental-mutation.mjs
@@ -1,10 +1,17 @@
 #!/usr/bin/env node
 // Run Stryker only against `src/**/*.ts` files that changed vs the merge-base
-// with the base branch.
+// with the base branch, then post surviving mutants as a PR comment.
 
 import { spawnSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
 
 const baseBranch = process.env.MUTATION_BASE_BRANCH ?? 'origin/master';
+const REPORT_PATH = 'reports/mutation/mutation-testing-report.json';
+const COMMENT_MARKER = '<!-- stryker-incremental-report -->';
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
 
 function git(...args) {
   const result = spawnSync('git', args, { encoding: 'utf-8' });
@@ -26,7 +33,148 @@ function listChangedSourceFiles() {
     .filter((line) => line.endsWith('.ts'));
 }
 
-function main() {
+// ---------------------------------------------------------------------------
+// Stryker JSON report parsing
+// ---------------------------------------------------------------------------
+
+function extractOriginal(source, location) {
+  const lines = source.split('\n');
+  const { start, end } = location;
+  if (start.line === end.line) {
+    return (lines[start.line - 1] ?? '').slice(start.column - 1, end.column - 1);
+  }
+  return (lines[start.line - 1] ?? '').slice(start.column - 1);
+}
+
+function parseSurvivors(reportPath) {
+  if (!existsSync(reportPath)) return null;
+  const report = JSON.parse(readFileSync(reportPath, 'utf-8'));
+  const survivors = [];
+  for (const [file, data] of Object.entries(report.files ?? {})) {
+    for (const mutant of data.mutants ?? []) {
+      if (mutant.status === 'Survived') {
+        survivors.push({
+          file,
+          line: mutant.location.start.line,
+          mutatorName: mutant.mutatorName,
+          original: extractOriginal(data.source, mutant.location),
+          replacement: mutant.replacement ?? '—',
+        });
+      }
+    }
+  }
+  survivors.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+  return survivors;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub PR comment
+// ---------------------------------------------------------------------------
+
+function getPRNumber() {
+  // GITHUB_REF format: refs/pull/123/merge
+  const refMatch = (process.env.GITHUB_REF ?? '').match(/refs\/pull\/(\d+)\//);
+  if (refMatch) return parseInt(refMatch[1], 10);
+
+  // Fallback: read from the event payload file
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && existsSync(eventPath)) {
+    try {
+      const event = JSON.parse(readFileSync(eventPath, 'utf-8'));
+      const number = event.pull_request?.number ?? event.number;
+      if (number) return number;
+    } catch {
+      // ignore parse errors
+    }
+  }
+  return null;
+}
+
+function formatComment(survivors, changedFiles) {
+  const fileList = changedFiles.map((f) => `\`${f}\``).join(', ');
+  const header = `${COMMENT_MARKER}\n## 🧬 Mutation Testing (incremental)\n_Scanned: ${fileList}_\n`;
+
+  if (survivors.length === 0) {
+    return `${header}\n✅ All mutants killed — no survivors on changed files.`;
+  }
+
+  const rows = survivors.map(
+    ({ file, line, mutatorName, original, replacement }) =>
+      `| \`${file}\` | ${line} | ${mutatorName} | \`${original}\` | \`${replacement}\` |`,
+  );
+
+  return [
+    header,
+    `⚠️ **${survivors.length} survived mutant(s)** — consider adding tests to kill them.\n`,
+    '| File | Line | Mutator | Original | Mutant |',
+    '|------|------|---------|----------|--------|',
+    ...rows,
+  ].join('\n');
+}
+
+async function upsertPRComment(token, repo, prNumber, body) {
+  const base = `https://api.github.com/repos/${repo}`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'Content-Type': 'application/json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  const listResp = await fetch(`${base}/issues/${prNumber}/comments?per_page=100`, { headers });
+  if (!listResp.ok) throw new Error(`Failed to list comments: ${listResp.status} ${listResp.statusText}`);
+
+  const comments = await listResp.json();
+  const existing = comments.find((c) => typeof c.body === 'string' && c.body.includes(COMMENT_MARKER));
+
+  const payload = JSON.stringify({ body });
+  if (existing) {
+    const patchResp = await fetch(`${base}/issues/comments/${existing.id}`, {
+      method: 'PATCH',
+      headers,
+      body: payload,
+    });
+    if (!patchResp.ok) throw new Error(`Failed to update comment: ${patchResp.status} ${patchResp.statusText}`);
+  } else {
+    const postResp = await fetch(`${base}/issues/${prNumber}/comments`, {
+      method: 'POST',
+      headers,
+      body: payload,
+    });
+    if (!postResp.ok) throw new Error(`Failed to create comment: ${postResp.status} ${postResp.statusText}`);
+  }
+}
+
+async function reportToGitHub(changedFiles) {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  const prNumber = getPRNumber();
+
+  if (!token || !repo || !prNumber) {
+    console.log('[incremental-mutation] GitHub context not available; skipping PR comment.');
+    return;
+  }
+
+  const survivors = parseSurvivors(REPORT_PATH);
+  if (survivors === null) {
+    console.log('[incremental-mutation] No JSON report found; skipping PR comment.');
+    return;
+  }
+
+  const body = formatComment(survivors, changedFiles);
+  try {
+    await upsertPRComment(token, repo, prNumber, body);
+    console.log(`[incremental-mutation] Posted ${survivors.length} survivor(s) to PR #${prNumber} (repo: ${repo}).`);
+  } catch (err) {
+    console.error(`[incremental-mutation] Failed to post GitHub comment: ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+async function main() {
   let files;
   try {
     files = listChangedSourceFiles();
@@ -48,7 +196,14 @@ function main() {
 
   const args = ['stryker', 'run', '--mutate', files.join(',')];
   const stryker = spawnSync('npx', args, { stdio: 'inherit', shell: true });
-  process.exit(stryker.status ?? 1);
+  const exitCode = stryker.status ?? 1;
+
+  await reportToGitHub(files);
+
+  process.exit(exitCode);
 }
 
-main();
+main().catch((err) => {
+  console.error('[incremental-mutation] Unexpected error:', err.message);
+  process.exit(1);
+});

--- a/test/units/parsers.test.ts
+++ b/test/units/parsers.test.ts
@@ -22,6 +22,11 @@ describe('tests of the extractTypeNamesFromManifestFile fn', () => {
 
     expect(result).to.deep.equal([]);
   });
+  it('should return results sorted alphabetically', async () => {
+    const result = await extractTypeNamesFromManifestFile('./samples/samplePackage.xml');
+    expect(result.length).toBeGreaterThan(1);
+    expect(result).toEqual([...result].sort((a, b) => a.localeCompare(b)));
+  });
 });
 
 describe('tests of the parseTestSuiteFile fn', () => {
@@ -34,6 +39,15 @@ describe('tests of the parseTestSuiteFile fn', () => {
 
   it('should throw on invalid XML', () => {
     expect(() => parseTestSuiteFile('<<< not valid xml >>>')).toThrow();
+  });
+
+  it('should throw the xml parse error, not a downstream TypeError', () => {
+    try {
+      parseTestSuiteFile('<<< not valid xml >>>');
+      expect.fail('should have thrown');
+    } catch (e) {
+      expect(e).not.toBeInstanceOf(TypeError);
+    }
   });
 });
 
@@ -70,6 +84,18 @@ describe('tests of the parseTestSuitesNames fn', () => {
   it('should return empty array for empty array', () => {
     expect(parseTestSuitesNames([])).to.deep.equal([]);
   });
+
+  it('should handle spaces before the colon in @testsuites annotation', () => {
+    expect(parseTestSuitesNames(['@testsuites   :SuiteA'])).toEqual(['SuiteA']);
+  });
+
+  it('should collapse consecutive commas between suite names', () => {
+    expect(parseTestSuitesNames(['@testsuites:SuiteA,,SuiteB'])).toEqual(['SuiteA', 'SuiteB']);
+  });
+
+  it('should trim trailing separators', () => {
+    expect(parseTestSuitesNames(['@testsuites:SuiteA,'])).toEqual(['SuiteA']);
+  });
 });
 
 describe('tests of the selectRelevantTests fn', () => {
@@ -81,12 +107,74 @@ describe('tests of the selectRelevantTests fn', () => {
     const result = selectRelevantTests(testMap, ['Flow:SomeFlow']);
     expect(result).to.deep.equal(['MatchingTest']);
   });
+
+  it('uses exact match for dependencies without wildcards', () => {
+    // 'A.BXC' matches regex ^A\.B.C$ (second dot unescaped) but not exact string 'A.B.C'
+    const testMap = { TestA: ['A.B.C'] };
+    expect(selectRelevantTests(testMap, ['A.BXC'])).toEqual([]);
+  });
+
+  it('requires a literal dot in wildcard patterns', () => {
+    const testMap = { TestA: ['CustomField.*'] };
+    // No dot after CustomField — escaped-dot regex should not match
+    expect(selectRelevantTests(testMap, ['CustomFieldNoDot'])).toEqual([]);
+  });
+
+  it('wildcard does not match unrelated metadata prefix', () => {
+    const testMap = { TestA: ['Foo.*'] };
+    expect(selectRelevantTests(testMap, ['Bar.Something'])).toEqual([]);
+  });
+
+  it('wildcard matches metadata with the correct prefix and a literal dot', () => {
+    const testMap = { TestA: ['CustomField:Account.*'] };
+    expect(selectRelevantTests(testMap, ['CustomField:Account.Name'])).toEqual(['TestA']);
+  });
 });
 
 describe('tests of the loadTestMetadataDependencies fn', () => {
   it('should throw on invalid YAML structure', async () => {
     const tempFile = join(tmpdir(), `invalid-metadata-${Date.now()}.yml`);
     await writeFile(tempFile, 'just a string value');
+    try {
+      await expect(loadTestMetadataDependencies(tempFile)).rejects.toThrow('Invalid test metadata dependencies format');
+    } finally {
+      await unlink(tempFile);
+    }
+  });
+
+  it('should throw on null YAML value', async () => {
+    const tempFile = join(tmpdir(), `null-metadata-${Date.now()}.yml`);
+    await writeFile(tempFile, 'null');
+    try {
+      await expect(loadTestMetadataDependencies(tempFile)).rejects.toThrow('Invalid test metadata dependencies format');
+    } finally {
+      await unlink(tempFile);
+    }
+  });
+
+  it('should throw when top-level YAML value is a number', async () => {
+    const tempFile = join(tmpdir(), `number-metadata-${Date.now()}.yml`);
+    await writeFile(tempFile, '123');
+    try {
+      await expect(loadTestMetadataDependencies(tempFile)).rejects.toThrow('Invalid test metadata dependencies format');
+    } finally {
+      await unlink(tempFile);
+    }
+  });
+
+  it('should throw when map values are not arrays', async () => {
+    const tempFile = join(tmpdir(), `not-array-${Date.now()}.yml`);
+    await writeFile(tempFile, 'TestClass: "not-an-array"');
+    try {
+      await expect(loadTestMetadataDependencies(tempFile)).rejects.toThrow('Invalid test metadata dependencies format');
+    } finally {
+      await unlink(tempFile);
+    }
+  });
+
+  it('should throw when array elements are not strings', async () => {
+    const tempFile = join(tmpdir(), `non-string-${Date.now()}.yml`);
+    await writeFile(tempFile, 'TestClass:\n  - valid\n  - 123');
     try {
       await expect(loadTestMetadataDependencies(tempFile)).rejects.toThrow('Invalid test metadata dependencies format');
     } finally {

--- a/test/units/readers.test.ts
+++ b/test/units/readers.test.ts
@@ -97,3 +97,99 @@ describe('test suite wildcards', () => {
     expect(result).to.deep.equal(tests);
   });
 });
+
+describe('searchDirectoryForTestClasses file type filtering', () => {
+  it('should not process non-.cls and non-.trigger files', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'non-apex-'));
+    await writeFile(join(tempDir, 'README.txt'), 'not a class');
+    await writeFile(join(tempDir, 'Sample.cls'), '// @Tests: SomeTest');
+    try {
+      const result = await searchDirectoryForTestClasses(tempDir, null);
+      expect(result.warnings).toEqual([]);
+      expect(result.classes).toContain('SomeTest');
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+
+  it('should match trigger files using the ApexTrigger prefix', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'trigger-'));
+    await writeFile(join(tempDir, 'MyTrigger.trigger'), '// @Tests: TriggerTest');
+    try {
+      const result = await searchDirectoryForTestClasses(tempDir, ['ApexTrigger:MyTrigger']);
+      expect(result.classes).toContain('TriggerTest');
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+
+  it('should match cls files using the ApexClass prefix', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'apexclass-'));
+    await writeFile(join(tempDir, 'MyClass.cls'), '// @Tests: MyTest');
+    try {
+      const result = await searchDirectoryForTestClasses(tempDir, ['ApexClass:MyClass']);
+      expect(result.classes).toContain('MyTest');
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+});
+
+describe('searchDirectoryForTestClasses annotation detection', () => {
+  it('should not warn for files with only @tests annotation', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'tests-only-'));
+    await writeFile(join(tempDir, 'MyClass.cls'), '// @Tests: MyTest');
+    try {
+      const result = await searchDirectoryForTestClasses(tempDir, null);
+      expect(result.warnings).toEqual([]);
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+
+  it('should not warn for files with only @isTest annotation', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'istest-only-'));
+    await writeFile(join(tempDir, 'MyTestClass.cls'), '@isTest\npublic class MyTestClass {}');
+    try {
+      const result = await searchDirectoryForTestClasses(tempDir, null);
+      expect(result.warnings).toEqual([]);
+      expect(result.classes).toContain('MyTestClass');
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+});
+
+describe('searchDirectoryForTestNamesInTestSuites file type filtering', () => {
+  it('should only process .testSuite-meta.xml files', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'suite-filter-'));
+    await writeFile(
+      join(tempDir, 'Valid.testSuite-meta.xml'),
+      '<?xml version="1.0" encoding="UTF-8"?>\n<ApexTestSuite xmlns="http://soap.sforce.com/2006/04/metadata">\n  <testClassName>ValidTest</testClassName>\n</ApexTestSuite>',
+    );
+    await writeFile(join(tempDir, 'SomeClass.cls'), 'public class SomeClass {}');
+    try {
+      const result = await searchDirectoryForTestNamesInTestSuites(tempDir, []);
+      expect(result).toEqual(['ValidTest']);
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+});
+
+describe('searchDirectoryForTestNamesInTestSuites wildcard guard', () => {
+  it('should not search package directories when suite contains no wildcards', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'no-wildcard-'));
+    await writeFile(
+      join(tempDir, 'Plain.testSuite-meta.xml'),
+      '<?xml version="1.0" encoding="UTF-8"?>\n<ApexTestSuite xmlns="http://soap.sforce.com/2006/04/metadata">\n  <testClassName>PlainTest</testClassName>\n</ApexTestSuite>',
+    );
+    try {
+      // Non-existent dir should never be accessed since requiresWildcardSearch stays false
+      const result = await searchDirectoryForTestNamesInTestSuites(tempDir, ['/this/path/does/not/exist']);
+      expect(result).toEqual(['PlainTest']);
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+});

--- a/test/units/utils.test.ts
+++ b/test/units/utils.test.ts
@@ -1,11 +1,12 @@
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { tmpdir, availableParallelism } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
 import { formatList } from '../../src/utils/formatters.js';
 import { getRepoRoot } from '../../src/utils/getRepoRoot.js';
 import { validateTests } from '../../src/utils/validateTests.js';
+import { getConcurrencyThreshold } from '../../src/utils/concurrencyThreshold.js';
 
 describe('formatList', () => {
   it('sfdx format joins tests with space', async () => {
@@ -28,6 +29,20 @@ describe('getRepoRoot', () => {
     vi.spyOn(process, 'cwd').mockReturnValue('C:\\definitely-no-sfdx-project-json-here\\deep\\path');
     await expect(getRepoRoot()).rejects.toThrow('sfdx-project.json not found in any parent directory.');
   });
+
+  it('finds sfdx-project.json by traversing parent directories', async () => {
+    const tempBase = await mkdtemp(join(tmpdir(), 'repo-root-'));
+    const subDir = join(tempBase, 'src', 'deep');
+    await mkdir(subDir, { recursive: true });
+    await writeFile(join(tempBase, 'sfdx-project.json'), '{}');
+    vi.spyOn(process, 'cwd').mockReturnValue(subDir);
+    try {
+      const { repoRoot } = await getRepoRoot();
+      expect(repoRoot).toBe(tempBase);
+    } finally {
+      await rm(tempBase, { recursive: true });
+    }
+  });
 });
 
 describe('validateTests', () => {
@@ -44,5 +59,26 @@ describe('validateTests', () => {
     } finally {
       await rm(tempDir, { recursive: true });
     }
+  });
+
+  it('finds file in second directory when absent from first', async () => {
+    const dir1 = await mkdtemp(join(tmpdir(), 'val1-'));
+    const dir2 = await mkdtemp(join(tmpdir(), 'val2-'));
+    await writeFile(join(dir2, 'SomeTest.cls'), '');
+    try {
+      const { validatedTests, warnings } = await validateTests(['SomeTest'], [dir1, dir2]);
+      expect(validatedTests).toEqual(['SomeTest']);
+      expect(warnings).toEqual([]);
+    } finally {
+      await rm(dir1, { recursive: true });
+      await rm(dir2, { recursive: true });
+    }
+  });
+});
+
+describe('getConcurrencyThreshold', () => {
+  it('returns Math.min of availableParallelism and 6', () => {
+    const result = getConcurrencyThreshold();
+    expect(result).toBe(Math.min(availableParallelism(), 6));
   });
 });


### PR DESCRIPTION
## Summary

- Adds unit tests targeting 40+ surviving Stryker mutants across `parsers`, `readers`, and `utils`
- Updates `scripts/incremental-mutation.mjs` to parse the Stryker JSON report after each run and upsert a summary comment on the PR
- Passes `GITHUB_TOKEN` to the incremental mutation workflow step

## Tests added

| File | What's covered |
|------|---------------|
| `utils.test.ts` | `getConcurrencyThreshold` cap at 6, `getRepoRoot` parent-dir traversal, `validateTests` file in second directory |
| `parsers.test.ts` | `extractTypeNamesFromManifestFile` sorted output, `parseTestSuiteFile` error type, `parseTestSuitesNames` edge cases (spaces, consecutive commas, trailing separator), `loadTestMetadataDependencies` null/number/non-array/non-string YAML, `selectRelevantTests` exact-match multi-dot, dot in wildcard, non-matching wildcard |
| `readers.test.ts` | Non-apex file exclusion, `ApexTrigger`/`ApexClass` prefix matching, `@tests`-only and `@isTest`-only annotation detection, non-suite file exclusion, wildcard guard skips package dir search |

## PR comment reporting

After Stryker finishes, the script now:
1. Reads `reports/mutation/mutation-testing-report.json` (already configured)
2. Extracts `Survived` mutants with file, line, mutator name, original text, and replacement
3. Finds any existing comment with `<!-- stryker-incremental-report -->` and PATCHes it, or POSTs a new one — avoids spam on re-runs
4. Failures are logged as warnings and do not affect Stryker's exit code

## Test plan

- [ ] Unit tests pass locally: `npm run test:unit`
- [ ] Incremental mutation CI runs on this PR and posts a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)